### PR TITLE
Update lint

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "scripts": {
     "build": "ember build",
+    "coverage": "COVERAGE=true ember test",
     "lint": "lint-all-the-things",
     "start": "ember server",
-    "test": "npm run lint && COVERAGE=true ember test"
+    "test": "npm run lint && ember test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,10 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
-    "coverage": "COVERAGE=true ember test",
-    "test": "npm run lint && ember test",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "eslint": "eslint *.js addon app blueprints config tests --fix",
-    "md-lint": "remark *.md",
-    "sass-lint": "sass-lint -q -v"
+    "lint": "lint-all-the-things",
+    "start": "ember server",
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": {
     "type": "git",
@@ -63,15 +59,10 @@
     "ember-sinon": "0.6.0",
     "ember-test-utils": "1.11.0",
     "ember-truth-helpers": "1.3.0",
-    "eslint": "^3.3.1",
-    "eslint-config-frost-standard": "^6.0.0",
     "loader.js": "^4.0.11",
     "lodash-es": "4.15.0",
     "redux": "3.6.0",
     "redux-thunk": "2.1.0",
-    "remark-cli": "^2.0.0",
-    "remark-lint": "^5.1.0",
-    "sass-lint": "^1.0.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0"
   },

--- a/tests/integration/components/ember-dewey-docs-test.js
+++ b/tests/integration/components/ember-dewey-docs-test.js
@@ -1,29 +1,24 @@
 import {expect} from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'ember-dewey-docs',
-  'Integration: EmberDeweyDocsComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#ember-dewey-docs}}
-      //     template content
-      //   {{/ember-dewey-docs}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{ember-dewey-docs}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('ember-dewey-docs')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#ember-dewey-docs}}
+    //     template content
+    //   {{/ember-dewey-docs}}
+    // `);
+
+    this.render(hbs`{{ember-dewey-docs}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/property-control-test.js
+++ b/tests/integration/components/property-control-test.js
@@ -1,29 +1,24 @@
 import {expect} from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'property-control',
-  'Integration: PropertyControlComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#property-control}}
-      //     template content
-      //   {{/property-control}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{property-control}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('property-control')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#property-control}}
+    //     template content
+    //   {{/property-control}}
+    // `);
+
+    this.render(hbs`{{property-control}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-dewey-docs/issues/3

# CHANGELOG
* **Updated** deprecated describeComponent to now use setupComponentTest through the test helpers in `ember-test-utils`.
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.