### PR TITLE
Update to use latest pr-bumper

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 ### This project uses [semver](semver.org), please check the scope of this pr:
- - [ ] #patch# - backwards-compatible bug fix
- - [ ] #minor# - adding functionality in a backwards-compatible manner
- - [ ] #major# - incompatible API change
+
+- [ ] #none# - documentation fixes and/or test additions
+- [ ] #patch# - backwards-compatible bug fix
+- [ ] #minor# - adding functionality in a backwards-compatible manner
+- [ ] #major# - incompatible API change
 
 # CHANGELOG
 Please add a description of your change here, it will be automatically prepended to the `CHANGELOG.md` file.

--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -1,0 +1,3 @@
+{
+  "dependencySnapshotFile": ""
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,24 @@
-language: node_js
 sudo: required
 dist: trusty
+language: node_js
+
 node_js:
-- '6.9'
+- '6.9.1'
 - 'stable'
-branches:
-  except:
-  - /^v[0-9\.]+/
-before_install:
-- npm install -g coveralls pr-bumper
-- pr-bumper check
-before_script:
-- export CHROME_BIN=/usr/bin/google-chrome
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- sleep 3 # give xvfb some time to start
-- sudo apt-get update
-- sudo apt-get install -y libappindicator1 fonts-liberation
-- wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-- sudo dpkg -i google-chrome*.deb
-script:
-- npm run lint
-- ember try:one $EMBER_TRY_SCENARIO
-install:
-- npm install
-- bower install
-after_success:
-- .travis/publish-coverage.sh
+
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - google-chrome
     packages:
+    - google-chrome-stable
     - g++-4.8
+
+cache:
+  directories:
+  - node_modules
+
 env:
   matrix:
   - EMBER_TRY_SCENARIO=default
@@ -40,8 +26,33 @@ env:
   global:
     - CXX=g++-4.8
     - secure: tq2xsKq+N8mr7PBpcUSUIfEIH2TEYMEqXGTCei94GeyNFo8BVykr81oSCxMbxVaMi/qp7d2v/Ptrk+wECBCQ52l8x4H9C1yGm7jk0b8Nl+3lUegjvjSDwojUIahGu0wcNm1Y4vwZ6t2It1qlLrOQmzqD9/5cIvI6HNiEhrUcSY9RkfxAiWzm55RFS5oqOEu1Dib71irSbPgl06Epfz8/VaI5t88nXavz+4uQYBHBWnY2auJsQOpxpr1DsgvtrLs6ycfSUF58httIeLJ7h/wtkobgZfVb1eBKd3bh3goIstKuwclZinZfL5BXnHhOUUn0OoT51B5oGhcgGK11frXdzXCgGPItJ/X8Q43srDWe+an4Z2lZgMnBVkk54EjGU2iTPF9rSSP+flaQaIabl0ZPYeGxmgoH0QeGx7oDV4w57aJcjX6L5zJ47W0c9tLFHXicJcasb4gtbRLxAaey54XeI1ItoTkPcARFUHD6B5lisiIjAcsfNWelIcY4jhdAXMBqUbkzxYykeN+p4x7m095DE2eucf4LRVFHHV2Bi+X31smLaKzShHwQLOlSJPUfpUvqE/6toA7x45wszGKtpzET7D/4jzB3tLZtASNrIekzhrpKmpLa7PF/iIpljCn2j8m+cHyXUQo/7C3n09iMsZEDG6bctsMus06sCDJdFg0bnic=
-before_deploy:
-- pr-bumper bump
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - env: EMBER_TRY_SCENARIO=ember-release
+
+before_install:
+- npm config set spin false
+- npm install -g coveralls pr-bumper@^1.0.0
+- $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
+
+install:
+- $(npm root -g)/pr-bumper/.travis/maybe-install.sh
+
+before_script:
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+- sleep 3 # give xvfb some time to start
+
+script:
+- $(npm root -g)/pr-bumper/.travis/maybe-test.sh
+- .travis/maybe-bump-version.sh
+
+after_success:
+- .travis/maybe-publish-coverage.sh
+- .travis/maybe-publish-gh-pages.sh
+
 deploy:
   provider: npm
   email: npm.ciena@gmail.com
@@ -49,12 +60,11 @@ deploy:
   api_key:
     secure: XswbQ7GrToCl1wzJH+P6muh9tLkwsrXcGypDQWXgSwfQYKxcZslX80fLvn5LgbDqR/rrt0hrmxqrkGx+/yIq8aEqiY72loD0uAeXLCV8f5F7+jcsUsdb9woYDVlnrQfjdHoT9e8xASK9ycNfGD1KAIaqblxSbAhydls5DzIRCfFCbexJVLFMqQ39ydXNcFAQydYX8P3j/97usrn6olWP+G4bKyRSZbEg/faDf5yp1lpMciYe/PrS0f6xtds7opIzkBSTamN/c+POgXxD/9mbTYyC7uX3qAIc77hFmhlva/fPR5TidXA1MOKNAufHjeV+UwPHGruXj4Jv02GkElOwllnOWqapfgTGiLSV/t+a09po6P2txc+0d1tq2kI8p1EePiYSDZteFHxpu3eHGkieZWNFG/5qZgmVINfpVF1HtiRen4MgWic6qe78PHIl94aS3XhqO9i81oHB/c4udJcZ8XjDHwMasBiS6Dbkaqy65hjfBJgI9lC2lpVFGamsJDSd/1DII28ZI4aY//Gl5O83K3V4Eippf/21Ow+SggBGTJmYEFqks5jzQv9R+lASdiUednUcJmbtn2hdRt74RDx2LPyjoe1qSCwYYcQq+2oikHuQeJzsdECOg/kZYAN4jrUZ6hnGd/3bMdB+qzixrYcvaCTOPDME7DykQt9hGO8enq8=
   on:
-    branch: master
+    all_branches: true
     condition: "$EMBER_TRY_SCENARIO = 'default'"
-    node: 'stable'
+    node: '6.9.1'
     tags: true
-after_deploy:
-- .travis/publish-gh-pages.sh
+
 notifications:
   slack:
     secure: Z9vPmnNUziqCumxBabZVWMR5mdW9+o4zAW6RRYfeeBEJeUjuneoFYdUFHt8gDWaALuMAcb9ua80jIFqh9TMJDYbDB/ecAyd40+qDZufCB+yVcJbBuY2yLcUfyhj20xrKfUzsV4Fk+TVHGDO/EratApfPZcNujpubzznVmuSM1Fzlej1+1CAqruVpSvtJg9y9chEk4fSnExUfso/8ggas1iZl8HBUa960eyoNGc2Zn7ZBoMSwl/0DrJy22urwRuVTqANxe7JqrPMkz7OBoL1cp0sUNynNMZw3tkQFzxpCTI7X7RFJpgWxETBoOeZROxUNNcsoE455qQ33RYUgovVJb5Lr+AYTY9nOSi4apXIwfxXdSOk10pgpb+8UtpixVY6ti/mO1LPufbTTclf56Ytq+SHifrsLufGp8kzcGyoHEyqHE0oaTiS+wrBgZU63XVlGlOXFTLJc4CxNe7YlMx43bBm8Es3ydvKmhj6eR/AhuQ6TG7tBQs/68Ldvp5aCA56dedxYupFjr0YjyriWNHXvm7Bdrt66kbDod647Hub9GcNcw8UQwixJkDtFeg5pqzfBhOdqePvSiSuA5YdnHzAhFJAUY2mBfite/RVipCLTimrBDu0xNNP+YA12QDNLSOUX1A2Bxw/NjZNfDTh9Bs+67PCfAEHa0BgHyzuU34Gh4VY=

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+then
+  echo "Skipping version bump for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  exit 0
+fi
+
+if [ "$EMBER_TRY_SCENARIO" != "default" ]
+then
+  echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
+$(npm root -g)/pr-bumper/.travis/maybe-bump-version.sh

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source $(npm root -g)/pr-bumper/.travis/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping coverage publish for version bump commit"
+  exit 0
+fi
+
+if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+then
+  echo "Skipping coverage publish for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  exit 0
+fi
+
+if [ "$EMBER_TRY_SCENARIO" != "default" ]
+then
+  echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
+cat coverage/lcov.info | coveralls

--- a/.travis/maybe-publish-gh-pages.sh
+++ b/.travis/maybe-publish-gh-pages.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(npm root -g)/pr-bumper/.travis/is-bump-commit.sh
+
+if isBumpCommit
+then
+  echo "Skipping gh-pages publish for version bump commit"
+  exit 0
+fi
+
 VERSION=`node -e "console.log(require('./package.json').version)"`
 TMP_GH_PAGES_DIR=.gh-pages-demo
 

--- a/.travis/publish-coverage.sh
+++ b/.travis/publish-coverage.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
-then
-  echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
-  exit 0
-fi
-
-cat coverage/lcov.info | coveralls

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "coverage": "COVERAGE=true ember test",
     "lint": "lint-all-the-things",
     "start": "ember server",
-    "test": "npm run lint && ember test"
+    "test": "npm run lint && npm run test-addon",
+    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- ember test"
   },
   "repository": {
     "type": "git",

--- a/testem.js
+++ b/testem.js
@@ -1,11 +1,15 @@
+var Reporter = require('ember-test-utils/reporter')
+
 module.exports = {
-  'framework': 'mocha',
-  'test_page': 'tests/index.html?hidepassed&coverage',
-  'disable_watching': true,
-  'launch_in_ci': [
+  disable_watching: true,
+  framework: 'mocha',
+  launch_in_ci: [
+    'Chrome',
+    'Firefox'
+  ],
+  launch_in_dev: [
     'Chrome'
   ],
-  'launch_in_dev': [
-    'Chrome'
-  ]
+  reporter: new Reporter(),
+  test_page: 'tests/index.html?hidepassed'
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-dewey-docs/issues/5

# CHANGELOG
* **Updated** to use latest pr-bumper which supports being able to set a PR to `none` when publishing a new version is not desired.